### PR TITLE
Fix GUI callback scheduling

### DIFF
--- a/pomodoro.py
+++ b/pomodoro.py
@@ -48,7 +48,7 @@ class PomodoroApp:
         while self.is_running and self.time_left > 0:
             time.sleep(1)
             self.time_left -= 1
-            self.root.after(0, self.update_label())
+            self.root.after(0, self.update_label)
         if self.is_running and self.time_left == 0:
             self.beep()
             if self.is_pomodoro:
@@ -61,7 +61,7 @@ class PomodoroApp:
                 self.is_pomodoro = True
                 self.time_left = POMODORO_DURATION
                 self.status_label.config(text="Pomodoro")
-            self.root.after(0, self.update_label())
+            self.root.after(0, self.update_label)
             self.timer_countdown()  # Ricomincia automaticamente
 
     def start_timer(self):


### PR DESCRIPTION
## Summary
- fix `root.after` calls by passing the callback instead of invoking it

## Testing
- `python3 -m py_compile pomodoro.py`


------
https://chatgpt.com/codex/tasks/task_e_68725ccdf2a0832bbe0c9db6d305f29d